### PR TITLE
feat: import auth repo and add sa key for tests

### DIFF
--- a/actions-test-infra/auth/sa.tf
+++ b/actions-test-infra/auth/sa.tf
@@ -14,19 +14,12 @@
  * limitations under the License.
  */
 
-locals {
-  secrets = {
-    "WIF_PROVIDER_NAME" : module.oidc.provider_name,
-    "OIDC_AUTH_SA_EMAIL" : google_service_account.oidc-auth-test-sa.email,
-    "OIDC_AUTH_TEST_SECRET_REF" : google_secret_manager_secret.secret.id,
-    "AUTH_SA_KEY_EMAIL" : google_service_account.auth-key.email,
-    "AUTH_SA_KEY_JSON" : base64decode(google_service_account_key.key.private_key),
-    "AUTH_SA_KEY_B64" : google_service_account_key.key.private_key
-  }
+
+resource "google_service_account" "auth-key" {
+  project    = var.gcp_project
+  account_id = "test-auth-json"
 }
 
-# <k,v> pair of secrets for repo
-output "secrets" {
-  value     = local.secrets
-  sensitive = true
+resource "google_service_account_key" "key" {
+  service_account_id = google_service_account.auth-key.name
 }

--- a/actions-test-infra/auth/secret.tf
+++ b/actions-test-infra/auth/secret.tf
@@ -41,3 +41,10 @@ resource "google_secret_manager_secret_iam_member" "access-secret" {
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.oidc-auth-test-sa.email}"
 }
+
+resource "google_secret_manager_secret_iam_member" "access-secret-key" {
+  provider  = google-beta
+  secret_id = google_secret_manager_secret.secret.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.auth-key.email}"
+}

--- a/actions-test-infra/auth/wif.tf
+++ b/actions-test-infra/auth/wif.tf
@@ -28,7 +28,7 @@ module "project-services" {
 
 module "oidc" {
   source  = "terraform-google-modules/github-actions-runners/google//modules/gh-oidc"
-  version = "~> 1.1"
+  version = "~> 2.0"
 
   project_id  = var.gcp_project
   pool_id     = "test-pool"

--- a/gh/modules/actions-repo/repo.tf
+++ b/gh/modules/actions-repo/repo.tf
@@ -21,6 +21,9 @@ resource "github_repository" "repo" {
   allow_rebase_merge   = false
   is_template          = false
   has_issues           = true
+delete_branch_on_merge = var.delete_branch_on_merge
+topics = var.topics
+has_downloads = var.has_downloads
   vulnerability_alerts = var.vulnerability_alerts
   dynamic "template" {
     for_each = var.template_repo_name == "" ? [] : [var.template_repo_name]

--- a/gh/modules/actions-repo/variables.tf
+++ b/gh/modules/actions-repo/variables.tf
@@ -97,5 +97,5 @@ variable "topics" {
 variable "has_downloads" {
   type        = bool
   default     = false
-  description = " Set to true to enable the (deprecated) downloads features on the repository."
+  description = "Set to true to enable the (deprecated) downloads features on the repository."
 }

--- a/gh/modules/actions-repo/variables.tf
+++ b/gh/modules/actions-repo/variables.tf
@@ -81,3 +81,21 @@ variable "enforce_admins" {
   default     = false
   description = "Flag to enforce status checks for repository administrators"
 }
+
+variable "delete_branch_on_merge" {
+  type        = bool
+  default     = false
+  description = "Automatically delete head branch after a pull request is merged"
+}
+
+variable "topics" {
+  type        = list(string)
+  default     = null
+  description = "The list of topics of the repository."
+}
+
+variable "has_downloads" {
+  type        = bool
+  default     = false
+  description = " Set to true to enable the (deprecated) downloads features on the repository."
+}

--- a/gh/repos/repos.tf
+++ b/gh/repos/repos.tf
@@ -93,6 +93,15 @@ locals {
       description : "This action allows you to ssh into a Compute Engine instance.",
       templated : false,
     },
+    {
+      name : "auth",
+      description : "GitHub Action for authenticating to Google Cloud with GitHub Actions OIDC tokens and Workload Identity Federation.",
+      templated : false,
+      topics : ["github-actions", "google-cloud", "identity", "security"],
+      delete_branch_on_merge : true,
+      has_downloads : true,
+      secrets : data.terraform_remote_state.auth.outputs.secrets
+    },
   ]
 }
 
@@ -112,6 +121,12 @@ module "repos" {
     require_code_owner_reviews : can(repo.require_code_owner_reviews) ? repo.require_code_owner_reviews : true
     # enfore admins
     enforce_admins : can(repo.enforce_admins) ? repo.enforce_admins : false
+    # auto delete branch after merging PR
+    delete_branch_on_merge : can(repo.delete_branch_on_merge) ? repo.delete_branch_on_merge : false
+    # topics
+    topics : can(repo.topics) ? repo.topics : null
+    # has_downloads
+    has_downloads : can(repo.has_downloads) ? repo.has_downloads : false
   } }
   gh_org                     = local.gh_org
   repo_name                  = each.key
@@ -122,6 +137,9 @@ module "repos" {
   require_code_owner_reviews = each.value.require_code_owner_reviews
   enforce_admins             = each.value.enforce_admins
   gha_bot_token              = data.google_secret_manager_secret_version.bot.secret_data
+  delete_branch_on_merge     = each.value.delete_branch_on_merge
+  topics                     = each.value.topics
+  has_downloads              = each.value.has_downloads
   # if templated repo use google-github-actions-template
   template_repo_name = each.value.templated ? "google-github-actions-template" : ""
 }

--- a/gh/repos/test_infra_sources.tf
+++ b/gh/repos/test_infra_sources.tf
@@ -78,3 +78,10 @@ data "terraform_remote_state" "setup-sdk-infra" {
   }
 }
 
+data "terraform_remote_state" "auth" {
+  backend = "gcs"
+  config = {
+    bucket = "actions-infra-tfstate-b4fa"
+    prefix = "state/auth"
+  }
+}


### PR DESCRIPTION
This imports auth repo to be managed by Terraform and sets up a SA key for use in integration tests.