### PR TITLE
feat: ssh-compute test infra

### DIFF
--- a/actions-test-infra/ssh-compute/README.md
+++ b/actions-test-infra/ssh-compute/README.md
@@ -1,0 +1,5 @@
+# ssh-compute
+
+This configuration sets up two Compute Engine VMs on a VPC. One VM has an external IP while the other does not. Each VM has dedicated SAs attached to them. The goal is for two VMs is to test both IAP based SSH as well as regular SSH using the `ssh-compute` Action.
+
+IAP has been configured to use the VM without external IP. A NAT is also setup to provide egress for this VM. A FW rule allowing ingress for SSH has been created targeting the VM with an external IP. A common SA is granted `compute.instanceAdmin.v1` to allow updating metadata and to SSH into these VMs. This SA has also been granted `roles/iap.tunnelResourceAccessor` for accessing the VM with IAP.

--- a/actions-test-infra/ssh-compute/backend.tf
+++ b/actions-test-infra/ssh-compute/backend.tf
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  backend "gcs" {
+    bucket = "actions-infra-tfstate-b4fa"
+    prefix = "state/ssh-compute"
+  }
+}

--- a/actions-test-infra/ssh-compute/compute.tf
+++ b/actions-test-infra/ssh-compute/compute.tf
@@ -57,7 +57,7 @@ module "ssh-iap-vm" {
   name          = "ssh-iap-vm"
   zone          = "us-central1-a"
   image_project = "debian-cloud"
-  image_family  = "debian-9"
+  image_family  = "debian-10"
   machine_type  = "f1-micro"
   members       = ["serviceAccount:${google_service_account.ssh-sa.email}"]
 }
@@ -71,7 +71,7 @@ resource "google_service_account" "ssh-external-vm-sa" {
 
 # Assign the IAM Service Account User role on the VM SA:
 resource "google_service_account_iam_member" "external-vm-user" {
-  service_account_id = google_service_account.ssh-external-vm-sa.email
+  service_account_id = google_service_account.ssh-external-vm-sa.name
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.ssh-sa.email}"
 }

--- a/actions-test-infra/ssh-compute/compute.tf
+++ b/actions-test-infra/ssh-compute/compute.tf
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# VPC and subnet
+module "vpc" {
+  source  = "terraform-google-modules/network/google"
+  version = "~> 3.0"
+
+  project_id   = module.project-services.project_id
+  network_name = "test-ssh-compute-net"
+  routing_mode = "GLOBAL"
+
+  subnets = [
+    {
+      subnet_name           = "test-ssh-compute-subnet"
+      subnet_ip             = "10.127.0.0/20"
+      subnet_region         = "us-central1"
+      subnet_private_access = true
+    }
+  ]
+}
+
+# NAT for egress from VM without external IP
+module "cloud-nat" {
+  source  = "terraform-google-modules/cloud-nat/google"
+  version = "~> 2.0"
+
+  project_id    = module.project-services.project_id
+  region        = "us-central1"
+  router        = "ssh-compute-router"
+  network       = module.vpc.network_self_link
+  create_router = true
+}
+
+# VM with IAP setup
+module "ssh-iap-vm" {
+  source  = "terraform-google-modules/bastion-host/google"
+  version = "~> 4.0"
+
+  network       = module.vpc.network_self_link
+  subnet        = module.vpc.subnets_self_links[0]
+  project       = module.project-services.project_id
+  host_project  = module.project-services.project_id
+  name          = "ssh-iap-vm"
+  zone          = "us-central1-a"
+  image_project = "debian-cloud"
+  image_family  = "debian-9"
+  machine_type  = "f1-micro"
+  members       = ["serviceAccount:${google_service_account.ssh-sa.email}"]
+}
+
+# SA for VM with external IP
+resource "google_service_account" "ssh-external-vm-sa" {
+  project      = module.project-services.project_id
+  account_id   = "ssh-external-vm"
+  display_name = "ssh-external-vm"
+}
+
+# Assign the IAM Service Account User role on the VM SA:
+resource "google_service_account_iam_member" "external-vm-user" {
+  service_account_id = google_service_account.ssh-external-vm-sa.email
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.ssh-sa.email}"
+}
+
+# VM with external IP
+resource "google_compute_instance" "ssh-external-vm" {
+  name         = "ssh-external-vm"
+  project      = module.project-services.project_id
+  machine_type = "f1-micro"
+  zone         = "us-central1-a"
+  metadata = {
+    enable-oslogin = "TRUE"
+  }
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    subnetwork = module.vpc.subnets_self_links[0]
+    access_config {
+      // Ephemeral public IP
+    }
+  }
+
+  service_account {
+    email  = google_service_account.ssh-external-vm-sa.email
+    scopes = ["cloud-platform"]
+  }
+}
+
+# FW rule allowing ingress on port 22 for SSH targeting external IP VM SA
+resource "google_compute_firewall" "rules" {
+  project     = module.project-services.project_id
+  name        = "allow-ssh-ingress"
+  network     = module.vpc.network_name
+  description = "Allow SSH to external VM"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+  target_service_accounts = [google_service_account.ssh-external-vm-sa.email]
+}

--- a/actions-test-infra/ssh-compute/outputs.tf
+++ b/actions-test-infra/ssh-compute/outputs.tf
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  secrets = {
+    "SSH_COMPUTE_SA_EMAIL" : google_service_account.ssh-sa.email,
+    "SSH_COMPUTE_SA_KEY_JSON" : base64decode(google_service_account_key.key.private_key),
+    "SSH_COMPUTE_SA_KEY_B64" : google_service_account_key.key.private_key,
+    "SSH_COMPUTE_IAP_VM_NAME" : module.ssh-iap-vm.hostname,
+    "SSH_COMPUTE_EXTERNAL_VM_NAME" : google_compute_instance.ssh-external-vm.name
+  }
+}
+
+# <k,v> pair of secrets for repo
+output "secrets" {
+  value     = local.secrets
+  sensitive = true
+}

--- a/actions-test-infra/ssh-compute/providers.tf
+++ b/actions-test-infra/ssh-compute/providers.tf
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "google" {
+  version = "~> 3.53.0"
+  project = var.gcp_project
+}

--- a/actions-test-infra/ssh-compute/sa.tf
+++ b/actions-test-infra/ssh-compute/sa.tf
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Enable necessary APIs.
+module "project-services" {
+  source  = "terraform-google-modules/project-factory/google//modules/project_services"
+  version = "~> 9.0"
+
+  project_id = var.gcp_project
+
+  activate_apis = [
+    "compute.googleapis.com",
+    "iap.googleapis.com",
+  ]
+}
+
+# Create the service account for test access.
+resource "google_service_account" "ssh-sa" {
+  project      = module.project-services.project_id
+  account_id   = "test-ssh-sa"
+  display_name = "test-ssh-sa"
+}
+
+# Assign the instance admin role to the service account to update keys and ssh.
+resource "google_project_iam_member" "ssh-into-vms" {
+  role   = "roles/compute.instanceAdmin.v1"
+  member = "serviceAccount:${google_service_account.ssh-sa.email}"
+}
+
+# Create service account key.
+resource "google_service_account_key" "key" {
+  service_account_id = google_service_account.ssh-sa.name
+}

--- a/actions-test-infra/ssh-compute/variables.tf
+++ b/actions-test-infra/ssh-compute/variables.tf
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "gcp_project" {
+  type = string
+}

--- a/gh/repos/repos.tf
+++ b/gh/repos/repos.tf
@@ -92,6 +92,7 @@ locals {
       name : "ssh-compute",
       description : "This action allows you to ssh into a Compute Engine instance.",
       templated : false,
+      secrets : data.terraform_remote_state.ssh-compute.outputs.secrets
     },
     {
       name : "auth",

--- a/gh/repos/test_infra_sources.tf
+++ b/gh/repos/test_infra_sources.tf
@@ -85,3 +85,11 @@ data "terraform_remote_state" "auth" {
     prefix = "state/auth"
   }
 }
+
+data "terraform_remote_state" "ssh-compute" {
+  backend = "gcs"
+  config = {
+    bucket = "actions-infra-tfstate-b4fa"
+    prefix = "state/ssh-compute"
+  }
+}


### PR DESCRIPTION
This adds test infra for ssh-compute action including two VMs - one without external IP and IAP enabled and one with external IP and associated FW config.