### PR TITLE
feat: Added parameter resources for render-parameter-version repo (private for now)

### DIFF
--- a/project_render-parameter-version.tf
+++ b/project_render-parameter-version.tf
@@ -27,7 +27,11 @@ module "render-parameter-version" {
     "config",
   ], local.common_topics)
 
-  repo_variables = {}
+  repo_variables = {
+    "PARAMETER_NAME" : google_parameter_manager_parameter.parameter.id
+    "PARAMETER_VERSION_NAME" : google_parameter_manager_parameter_version.parameter-version.id
+    "REGIONAL_PARAMETER_NAME" : google_parameter_manager_regional_parameter.regional-parameter.id
+  }
 
   repo_visibility = "private"
 
@@ -41,4 +45,17 @@ module "render-parameter-version" {
   depends_on = [
     google_project_service.services,
   ]
+}
+
+resource "google_secret_manager_secret_iam_member" "member" {
+  secret_id = google_secret_manager_secret.secret-for-parameter.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = google_parameter_manager_parameter.parameter.policy_member[0].iam_policy_uid_principal
+}
+
+resource "google_secret_manager_regional_secret_iam_member" "member" {
+  secret_id = google_secret_manager_regional_secret.regional-secret-for-parameter.secret_id
+  location  = google_secret_manager_regional_secret.regional-secret-for-parameter.location
+  role      = "roles/secretmanager.secretAccessor"
+  member    = google_parameter_manager_regional_parameter.regional-parameter.policy_member[0].iam_policy_uid_principal
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -23,7 +23,7 @@ terraform {
     }
 
     google = {
-      version = "~> 6.8"
+      version = "~> 6.31"
     }
   }
 


### PR DESCRIPTION
- Added `google_parameter_manager_parameter`, `google_parameter_manager_parameter_version`, `google_secret_manager_secret` and `google_secret_manager_secret` resources to support the `render-parameter-version` use case.
- Provided `Secret Manager Secret Accessor` (`roles/secretmanager.secretAccessor`) permission to the Parameter Manager service account for accessing the render secret version.
- Enabled the `parametermanager.googleapis.com` API to allow integration with the Parameter Manager service.